### PR TITLE
add esm build with `index.mjs` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ all notable changes to this project will be documented in this file.
 the format is based on [keep a changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2021-05-23
+
+### added
+
+- esm build with `.mjs` extension for official nodejs esm import support
+
 ## [2.2.0] - 2020-12-30
 
 ### added

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "country-code-emoji",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "convert country codes (ISO 3166-1 alpha-2) to corresponding emoji flags (unicode regional indicator symbols)",
   "main": "lib/index.js",
   "repository": "github:thekelvinliu/country-code-emoji",
   "author": "kelvin liu <kelvin@thekelvinliu.com>",
   "license": "MIT",
   "module": "src/index.js",
-  "types": "types/index.d.ts",
+  "types": "lib/index.d.ts",
   "exports": {
-    "import": "./src/index.js",
+    "import": "./lib/index.mjs",
     "require": "./lib/index.js"
   },
   "homepage": "https://github.com/thekelvinliu/country-code-emoji#readme",
@@ -17,8 +17,10 @@
     "url": "https://github.com/thekelvinliu/country-code-emoji/issues"
   },
   "scripts": {
-    "build": "esbuild src/index.js --format=cjs --outdir=lib --target=node10",
-    "clean": "rm -rf coverage lib types",
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "esbuild src/index.js --format=cjs --outdir=lib --target=node12",
+    "build:esm": "esbuild src/index.js --format=esm --outfile=lib/index.mjs --target=node12",
+    "clean": "rm -rf coverage lib",
     "lint": "eslint .",
     "prepublishOnly": "yarn build && yarn types",
     "reset": "rm -rf node_modules package-lock.json yarn.lock",
@@ -41,8 +43,7 @@
   },
   "files": [
     "lib",
-    "src",
-    "types"
+    "src"
   ],
   "keywords": [
     "country",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "types"
+    "outDir": "lib"
   },
   "include": ["src/index.js"]
 }


### PR DESCRIPTION
add esm build with `index.mjs` output to fix #7

place builds and type defs in `lib` directory

update changelog and version