### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
   "module": "src/index.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "import": "./lib/index.mjs",
-    "require": "./lib/index.js"
+    "./package.json": "./package.json",
+    ".": {
+      "require": "./lib/index.js",
+      "default": "./lib/index.mjs"
+    }
   },
   "homepage": "https://github.com/thekelvinliu/country-code-emoji#readme",
   "bugs": {


### PR DESCRIPTION
When sub-modules contain multiple exports in react-native projects, the root package.json is required


Resolves: https://github.com/react-native-community/cli/issues/1168