### PR TITLE
Fix type exports for modern node/bundler resolution with typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "lib/index.d.ts",
   "exports": {
     "import": "./lib/index.mjs",
-    "require": "./lib/index.js"
+    "require": "./lib/index.js",
+    "types": "./lib/index.d.ts"
   },
   "homepage": "https://github.com/thekelvinliu/country-code-emoji#readme",
   "bugs": {


### PR DESCRIPTION
TS won't find the `.d.ts` file with `moduleResolution: 'bundler | 'node'`